### PR TITLE
Check conversion of shares to assests - tighter bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ out/
 # editors
 .idea
 .vscode
+.*.swp
 
 # well, looks strange to ignore package-lock, but we have only pretter and it's temproray
 package-lock.json

--- a/certora/scripts/verifyConversion.sh
+++ b/certora/scripts/verifyConversion.sh
@@ -22,4 +22,4 @@ certoraRun src/StaticATokenLM.sol \
                aave-v3-periphery=lib/aave-v3-periphery \
                solidity-utils=lib/solidity-utils/src \
     --send_only \
-    --msg "verify StaticATokenLM amounts & shares conversion"
+    --msg "verify StaticATokenLM amounts shares conversion"

--- a/certora/specs/sharesAssetsConversion.spec
+++ b/certora/specs/sharesAssetsConversion.spec
@@ -71,6 +71,23 @@ methods
 definition RAY() returns uint256 = (10 ^ 27);
 
 
+/* A not on the conversion functions
+ * ---------------------------------
+ * The conversion functions are:
+ * - assets to shares = S(a) = (a * R) // r
+ * - shares to assets = A(s) = (s * r) // R
+ * where a=assets, s=shares, R=RAY, r=rate
+ * 
+ * These imply:
+ *   a * R - r <= S(a) * r <= a * R    a*R/r - 1 <= S(a) <= a*R/r
+ *   s * r - R <= A(s) * R <= s * r    s*r/R - 1 <= A(s) <= s*r/R
+ * 
+ * Hence:
+ *   A(S(a)) >= S(a)*r/R - 1 >= (a*R/r - 1)*r/R - 1 = (a*R - r)/R - 1 = a - r/R - 1
+ *   S(A(s)) >= A(s)*R/r - 1 >= (s*r/R - 1)*R/r - 1 = (s*r - R)/r - 1 = s - R/r - 1
+ */
+
+
 // Converting amount to shares is rounded down.
 rule amountConversionRoundedDown(uint256 amount) {
 	uint256 shares = convertToShares(amount);
@@ -88,8 +105,7 @@ rule sharesConversionRoundedDown(uint256 shares) {
 
 
 // Converting amount to shares and back to amount is preserved (up to rounding).
-/* NOTE: This fails when rate() > RAY, since conversion to shares formula is:
- * (a * R) // r, where a=amount, R=RAY and r=rate().
+/* NOTE: The precision depends on the ratio rate/ray.
  */
 rule amountConversionPreserved(uint256 amount) {
  	require rate() <= RAY();
@@ -97,15 +113,12 @@ rule amountConversionPreserved(uint256 amount) {
  	mathint converted = to_mathint(convertToAssets(convertToShares(amount)));
 
 	// That converted <= mathamount was proved in amountConversionRoundedDown,
- 	assert mathamount - converted <= 1, "Too few converted assets";
+ 	assert mathamount - converted <= 1 + rate() / RAY(), "Too few converted assets";
  }
  
 
 // Converting shares to amount and back to shares is preserved up to RAY.
-/* NOTE: This implies that convertToAssets(shares)==0 whenever shares<RAY.
- * So this is probably A BUG OR A MISTAKE. This happens because the formula
- * for converting shares to assets is: (s * r) // R, where a=amount, R=RAY
- * and r=rate().
+/* NOTE: The precision depends on the ratio RAY/rate.
  */
 rule sharesConversionPreserved(uint256 shares) {
 	mathint mathshares = to_mathint(shares);
@@ -113,5 +126,5 @@ rule sharesConversionPreserved(uint256 shares) {
 	mathint converted = to_mathint(convertToShares(amount));
 
 	// That converted <= mathshare was proved in sharesConversionRoundedDown.
-	assert mathshares - converted < RAY(), "Too few converted shares";
+	assert mathshares - converted <= 1 + RAY() / rate(), "Too few converted shares";
 }


### PR DESCRIPTION
Tighter bounds to the conversion functions.
[Test results](https://vaas-stg.certora.com/output/98279/79e9fe6e1b894d97b2f915383d6b1981?anonymousKey=476ded329ba8b9aa1c2d58dcef23304a57c04131)